### PR TITLE
Did a few things.  1. pulled out all seeding code from migrations.  2…

### DIFF
--- a/migrations/20180630125443_coins_index.js
+++ b/migrations/20180630125443_coins_index.js
@@ -3,19 +3,6 @@ exports.up = (knex, Promise)=>{
     table.string('symbol').primary();
     table.string('coin_name');
     table.decimal('usd_per_unit');
-  }).then((response)=>{
-    return knex('coins_index').insert([
-      {coin_name:'Bitcoin',symbol:'BTC',usd_per_unit:6357.04},
-      {coin_name:'Ethereum',symbol:'ETH',usd_per_unit:447.578},
-      {coin_name:'Binance Coin',symbol:'BNB',usd_per_unit:14.4759},
-      {coin_name:'Monero',symbol:'XMR',usd_per_unit:131.075},
-      {coin_name:'Dash',symbol:'DASH',usd_per_unit:235.537},
-      {coin_name:'Nebulas',symbol:'NAS',usd_per_unit:4.7941},
-      {coin_name:'Ripple',symbol:'XRP',usd_per_unit:0.459986},
-      {coin_name:'Cardano',symbol:'ADA',usd_per_unit:0.135845},
-      {coin_name:'EOS',symbol:'EOS',usd_per_unit:8.06736},
-      {coin_name:'Litecoin',symbol:'LTC',usd_per_unit:80.4113}
-    ])
   })
   .catch((err)=>{
     return console.error("error from coins_index migration",err)

--- a/migrations/20180701122030_purchases.js
+++ b/migrations/20180701122030_purchases.js
@@ -1,5 +1,3 @@
-const purchaseData = require('../data/purchases');
-
 exports.up = (knex, Promise)=>{
   return knex.schema.createTable('purchases',(table)=>{
     table.increments('pch_id').primary();
@@ -9,9 +7,6 @@ exports.up = (knex, Promise)=>{
     table.decimal('pch_usd_per_unit')
     table.decimal('pch_units',16,10)
     table.boolean('withdrawn')
-  })
-  .then((response)=>{
-    return knex('purchases').insert(purchaseData)
   })
   .catch((err)=>{
     return console.error("error from purchase migration",err)

--- a/scripts/conversionsUpdate.js
+++ b/scripts/conversionsUpdate.js
@@ -10,7 +10,7 @@ const conversionsData = require('../data/conversions');
 //for fetching certain crypto prices at particular dates.
 
 let promiseArr = [];
-console.log(conversionsData[0])
+
 conversionsData.forEach((conversionEntry)=>{
   promiseArr.push(
     knex('trades_conversions')
@@ -31,14 +31,3 @@ conversionsData.forEach((conversionEntry)=>{
 })
 
 Promise.all(promiseArr);
-
-// knex('trades_conversions')
-//   .where('trade_id','=',conversionsData[0].trade_id)
-//   .update({
-//     usd_per_unit:conversionsData[0].usd_per_unit,
-//     bnb_price_usd:conversionsData[0].bnb_price_usd
-//   })
-//   .then((response)=>{
-//     console.log(response);
-//     knex.destroy();
-//   })

--- a/seeds/coins_index.js
+++ b/seeds/coins_index.js
@@ -1,0 +1,15 @@
+const cryptoPrices = require('../data/cryptoPricesAt30June2018');
+
+exports.seed = (knex, Promise)=>{
+  return knex('coins_index').del()
+    .then(()=> {
+      return knex('coins_index')
+        .insert(cryptoPrices)
+        .catch((err)=>{
+          console.error('error while inserting coins_index data',err);
+        });
+    })
+    .catch((err)=>{
+      console.error('error in coins_index seed file',err);
+    });
+};

--- a/seeds/purchases.js
+++ b/seeds/purchases.js
@@ -1,0 +1,15 @@
+const allPurchases = require('../data/purchases')
+
+exports.seed = (knex, Promise) => {
+  return knex('purchases').del()
+    .then( ()=> {
+      return knex('purchases')
+        .insert(allPurchases)
+        .catch((err)=>{
+          console.error('error while inserting purchase data',err);
+        });
+    })
+    .catch((err)=>{
+      console.error('error in purchases.js seed file',err);
+    })
+};

--- a/seeds/trades_conversions.js
+++ b/seeds/trades_conversions.js
@@ -1,0 +1,15 @@
+const allTradeConversions = require('../data/conversions');
+
+exports.seed = (knex, Promise)=> {
+  return knex('trades_conversions').del()
+    .then(()=>{
+      return knex('trades_conversions')
+        .insert(allTradeConversions)
+        .catch((err)=>{
+          console.error('error while inserting trades conversions',err);
+        });
+    })
+    .catch((err)=>{
+      console.error('error in trades_conversions.js seed file',err);
+    })
+};


### PR DESCRIPTION
…. Created seed files containing seed data (previously used by migrations).  3. Wrote a simple script which auto-populates the trades_conversions data with data -- alleviating my need for so many api requests.